### PR TITLE
Support Rails 3.2.2 + Gemfile + Version Bump (3.2.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-rdoc
-pkg
+Gemfile.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 Gemfile.lock
+rdoc
+pkg

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source :rubygems
+
+gemspec

--- a/README.rdoc
+++ b/README.rdoc
@@ -91,6 +91,8 @@ Note that if any of your after_save callbacks return false, the rest of them wil
 
 ActivePresenter was created, and is maintained by {Daniel Haran}[http://danielharan.com] and {James Golick}[http://jamesgolick.com] on the train ride to {RubyFringe}[http://rubyfringe.com] from Montreal.
 
+ActivePresenter for Rails 3 is currently maintained by {Josh Martin}[http://github.com/skiz] and {Johnno Loggie}[http://github.com/johnno]
+
 == License
 
 ActivePresenter is available under the {MIT License}[http://en.wikipedia.org/wiki/MIT_License]

--- a/active_presenter.gemspec
+++ b/active_presenter.gemspec
@@ -1,15 +1,16 @@
 Gem::Specification.new do |s|
   s.name = %q{active_presenter}
-  s.version = "1.3.0"
+  s.version = "3.2.2"
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.authors = ["James Golick and Daniel Haran"]
-  s.date = %q{2010-06-28}
+  s.authors = ["James Golick", "Daniel Haran", "Josh Martin", "Johnno Loggie"]
+  s.date = %q{2012-03-26}
   s.extra_rdoc_files = [
     "LICENSE",
     "README.rdoc"
   ]
   s.files = [
      "LICENSE",
+     "Gemfile",
      "README",
      "README.rdoc",
      "Rakefile",
@@ -34,5 +35,7 @@ Gem::Specification.new do |s|
     "test/lint_test.rb",
     "test/test_helper.rb"
   ]
-  s.add_runtime_dependency(%q<activerecord>, [">= 0"])
+  s.add_runtime_dependency(%q<activerecord>, [">= 3.0.10"])
+  s.add_development_dependency(%q<expectations>, [">= 2.0.0"])
+  s.add_development_dependency(%q<sqlite3>, [">= 1.3.5"])
 end

--- a/lib/active_presenter/base.rb
+++ b/lib/active_presenter/base.rb
@@ -12,7 +12,7 @@ module ActivePresenter
 
     define_model_callbacks :validation, :save
 
-    class_inheritable_accessor :presented
+    class_attribute :presented
     self.presented = {}
 
     # Indicates which models are to be presented by this presenter.
@@ -39,7 +39,8 @@ module ActivePresenter
           send(t).errors
         end
 
-        presented[t] = types_and_classes[t]
+        # We must reassign in derrived classes rather than mutating the attribute in Base
+        self.presented = self.presented.merge(t => types_and_classes[t])
       end
     end
 

--- a/lib/active_presenter/version.rb
+++ b/lib/active_presenter/version.rb
@@ -1,10 +1,8 @@
 module ActivePresenter
   module VERSION
-    MAJOR    = 2
-    MINOR    = 0
-    TINY     = 0
-    EXTRA    = "a"
-
-    STRING   = [MAJOR, MINOR, TINY].join('.') + EXTRA
+    MAJOR    = 3
+    MINOR    = 2
+    TINY     = 2
+    STRING   = [MAJOR, MINOR, TINY].join('.')
   end
 end


### PR DESCRIPTION
- Fixed deprecation of class_inheritable_attribute in rails 3.2+
- Added Gemfile
- Updated gemfile dependencies
- Tested with rails 3.0.10 through 3.2.2
- Bumped version to 3.2.2
- Added supporter/maintainer information for Rails 3

I would suggest tagging master and forking it off for LTS, then applying the rails3 branch to master.

Everyone should be running some version of rails 3 now. :)
